### PR TITLE
Add pre-req packages for ansible install

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -14,7 +14,7 @@ To install the necessary prereqs, run the following commands:
 ```console
 $ sudo pip3 install --upgrade pip
 $ pip install ansible
-$ sudo yum module install -y container-tools
+$ sudo yum module install -y container-tools container-selinux policycoreutils-python-utils podman
 ```
 
 ### Installation


### PR DESCRIPTION
I tried out the ansible scripts from a fresh vagrant image of "bento/fedora-32", and ran into some missing packages. Adding them to the README (hopefully portable across older versions of fedora and RHEL).

Signed-off-by: Brandon Lum <lumjjb@gmail.com>